### PR TITLE
added EXTRA_FLAGS variable to CUDA Makefile to provide the freedom to…

### DIFF
--- a/CUDA.make
+++ b/CUDA.make
@@ -1,6 +1,7 @@
+EXTRA_FLAGS?=-O3
 
 cuda-stream: main.cpp CUDAStream.cu
-	nvcc -std=c++11 -O3 -DCUDA $^ $(EXTRA_FLAGS) -o $@
+	nvcc -std=c++11 -DCUDA $^ $(EXTRA_FLAGS) -o $@
 
 .PHONY: clean
 clean:

--- a/CUDA.make
+++ b/CUDA.make
@@ -1,7 +1,7 @@
-EXTRA_FLAGS?=-O3
+CXXFLAGS?=-O3 -std=c++11
 
 cuda-stream: main.cpp CUDAStream.cu
-	nvcc -std=c++11 -DCUDA $^ $(EXTRA_FLAGS) -o $@
+	nvcc $(CXXFLAGS) -DCUDA $^ $(EXTRA_FLAGS) -o $@
 
 .PHONY: clean
 clean:

--- a/CUDA.make
+++ b/CUDA.make
@@ -1,7 +1,8 @@
-CXXFLAGS?=-O3 -std=c++11
+CXXFLAGS=-O3
+CUDA_CXX=nvcc
 
 cuda-stream: main.cpp CUDAStream.cu
-	nvcc $(CXXFLAGS) -DCUDA $^ $(EXTRA_FLAGS) -o $@
+	$(CUDA_CXX) -std=c++11 $(CXXFLAGS) -DCUDA $^ $(EXTRA_FLAGS) -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
… specify debug flags or gencode flags, 

in more detail, I ran into trouble when trying to benchmark more than `arraysize = 32*1024*1024`. This is due to the fact that by default, not `-gencode` flags or similar are setup for the nvcc call of the cuda GPU stream. This defaults to an SM that doesn't support an arraysize of this magnitude and hence the `init_arrays` fails with error code `0xb Invalid arguments`. We had the discussion about gencodes before in #8, but the new Makefile based build system doesn't reflect the outcome of #8.